### PR TITLE
Allow query caching through a new searching context (aims #29)

### DIFF
--- a/src/KGzocha/Searcher/Context/Doctrine/CachedQueryBuilderSearchingContext.php
+++ b/src/KGzocha/Searcher/Context/Doctrine/CachedQueryBuilderSearchingContext.php
@@ -1,28 +1,21 @@
 <?php
 
-/*
- * This file is part of the searcher package.
- *
- * (c) Daniel Ribeiro <drgomesp@gmail.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace KGzocha\Searcher\Context\Doctrine;
 
 /**
- * Class CachedQueryBuilderSearchingContext
+ * Use this class as a SearchingContext in order to allow all filter imposers
+ * to work with Doctrine's QueryBuilder, with query caching enabled by default.
  *
  * @author Daniel Ribeiro <drgomesp@gmail.com>
- * @package KGzocha\Searcher\Context\Doctrine
  */
 class CachedQueryBuilderSearchingContext extends QueryBuilderSearchingContext
 {
+    /**
+     * {@inheritdoc}
+     */
     public function getResults()
     {
-        return $this
-            ->getQueryBuilder()
+        return parent::getQueryBuilder()
             ->getQuery()
             ->useQueryCache(true)
             ->getResult();

--- a/src/KGzocha/Searcher/Context/Doctrine/CachedQueryBuilderSearchingContext.php
+++ b/src/KGzocha/Searcher/Context/Doctrine/CachedQueryBuilderSearchingContext.php
@@ -3,7 +3,7 @@
 namespace KGzocha\Searcher\Context\Doctrine;
 
 /**
- * Use this class as a SearchingContext in order to allow all filter imposers
+ * Use this class as a SearchingContext in order to allow all criteria builders
  * to work with Doctrine's QueryBuilder, with query caching enabled by default.
  *
  * @author Daniel Ribeiro <drgomesp@gmail.com>

--- a/src/KGzocha/Searcher/Context/Doctrine/CachedQueryBuilderSearchingContext.php
+++ b/src/KGzocha/Searcher/Context/Doctrine/CachedQueryBuilderSearchingContext.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the searcher package.
+ *
+ * (c) Daniel Ribeiro <drgomesp@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KGzocha\Searcher\Context\Doctrine;
+
+/**
+ * Class CachedQueryBuilderSearchingContext
+ *
+ * @author Daniel Ribeiro <drgomesp@gmail.com>
+ * @package KGzocha\Searcher\Context\Doctrine
+ */
+class CachedQueryBuilderSearchingContext extends QueryBuilderSearchingContext
+{
+    public function getResults()
+    {
+        return $this
+            ->getQueryBuilder()
+            ->getQuery()
+            ->useQueryCache(true)
+            ->getResult();
+    }
+}

--- a/tests/Context/AbstractSearchingContextTest.php
+++ b/tests/Context/AbstractSearchingContextTest.php
@@ -9,7 +9,6 @@ use KGzocha\Searcher\Context\AbstractSearchingContext;
  */
 class AbstractSearchingContextTest extends \PHPUnit_Framework_TestCase
 {
-
     public function testGetQueryBuilderMethod()
     {
         $queryBuilder = new \stdClass();

--- a/tests/Context/CachedQueryBuilderSearchingContextTest.php
+++ b/tests/Context/CachedQueryBuilderSearchingContextTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace KGzocha\Searcher\Test\Context;
+
+use KGzocha\Searcher\Context\Doctrine\CachedQueryBuilderSearchingContext;
+
+/**
+ * @author Daniel Ribeiro <drgomesp@gmail.com>
+ * @package KGzocha\Searcher\Test\Context
+ */
+class QueryCachedQueryBuilderSearchingContextTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Doctrine\ORM\QueryBuilder|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $queryBuilder;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->queryBuilder = $this->getMock('Doctrine\ORM\QueryBuilder', [], [], '', false);
+    }
+
+    public function testUseQueryCacheWhenGettingResultsShouldBeCalled()
+    {
+        $query = $this->getMock('\KGzocha\Searcher\Test\Context\QueryStub', [], ['useQueryCache'], '', false);
+
+        $this->queryBuilder
+            ->expects($this->once())
+            ->method('getQuery')
+            ->willReturn($query);
+
+        $query
+            ->expects($this->once())
+            ->method('useQueryCache')
+            ->with(true)
+            ->willReturn($query);
+
+        $context = new CachedQueryBuilderSearchingContext($this->queryBuilder);
+
+        $context->getResults();
+    }
+}

--- a/tests/Context/CachedQueryBuilderSearchingContextTest.php
+++ b/tests/Context/CachedQueryBuilderSearchingContextTest.php
@@ -8,7 +8,7 @@ use KGzocha\Searcher\Context\Doctrine\CachedQueryBuilderSearchingContext;
  * @author Daniel Ribeiro <drgomesp@gmail.com>
  * @package KGzocha\Searcher\Test\Context
  */
-class QueryCachedQueryBuilderSearchingContextTest extends \PHPUnit_Framework_TestCase
+class CachedQueryBuilderSearchingContextTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var \Doctrine\ORM\QueryBuilder|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Context/QueryStub.php
+++ b/tests/Context/QueryStub.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the searcher package.
+ *
+ * (c) Daniel Ribeiro <drgomesp@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KGzocha\Searcher\Test\Context;
+
+/**
+ * Stub for making sure that useQueryCache will be called.
+ *
+ * @author Daniel Ribeiro <drgomesp@gmail.com>
+ * @package KGzocha\Searcher\Test\Context
+ */
+class QueryStub
+{
+    /**
+     * @see \Doctrine\ORM\Query::useQueryCache()
+     */
+    public function useQueryCache($bool) {}
+
+    /**
+     * @see \Doctrine\ORM\Query::getResult()
+     */
+    public function getResult() {}
+}


### PR DESCRIPTION
This simply adds a way to use Doctrine's query caching feature from the QueryBuilder level. We still need to aim for Caching Implementation adapters at the bundle level.