### PR TITLE
[#100] Introduced strict types. Droped support for PHP 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,11 @@ language: php
 sudo: false
 
 php:
-  - '5.4'
-  - '5.5'
-  - '5.6'
   - '7.0'
-  - hhvm
   - nightly
 
 matrix:
   include:
-    - php: 5.4
-      env: deps=low
     - php: 7.0
       env: deps=low
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### What is that?
 *Searcher* is a framework-agnostic search query builder. Search queries are written using criterias and can be run against MySQL, MongoDB, ElasticSearch, files or whatever else you like.
-Supported PHP versions: >=5.4, 7 and HHVM. **Now tested also with [Humbug](https://github.com/padraic/humbug)**
+**Latest version is supporting only PHP 7**. **Now tested also with [Humbug](https://github.com/padraic/humbug)**
 
 ### See [this presentation](https://krzysztof-gzocha.github.io/searcher/) to understand better
 
@@ -51,7 +51,7 @@ class AgeRangeCriteria implements CriteriaInterface
     * Only required method.
     * If will return true, then it will be passed to some of the CriteriaBuilder(s)
     */
-    public function shouldBeApplied()
+    public function shouldBeApplied(): bool
     {
         return null !== $this->minimalAge && null !== $this->maximalAge;
     }
@@ -80,7 +80,8 @@ class AgeRangeCriteriaBuilder implements CriteriaBuilderInterface
 
     public function allowsCriteria(
         CriteriaInterface $criteria
-    ) {
+    ): bool
+    {
         return $criteria instanceof AgeRangeCriteria;
     }
 
@@ -89,7 +90,8 @@ class AgeRangeCriteriaBuilder implements CriteriaBuilderInterface
     */
     public function supportsSearchingContext(
         SearchingContextInterface $searchingContext
-    ) {
+    ): bool
+    {
         return $searchingContext instanceof QueryBuilderSearchingContext;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -32,16 +32,15 @@
         }
     },
     "require":{
-        "php": ">=5.4"
+        "php": "^7"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^5",
         "phpmd/phpmd": "^2.4.3",
         "doctrine/orm": "^2.5.0",
         "doctrine/mongodb-odm": "^1.0.0",
-        "ruflin/elastica": ">=2.1.0",
-        "symfony/finder": "^2.0.5",
-        "phpdocumentor/reflection-docblock": "2.0.4"
+        "ruflin/elastica": "^2.1.0",
+        "symfony/finder": "^2.0.5"
     },
     "scripts": {
         "test": ["phpunit tests/"],

--- a/docs/chain-search.rst
+++ b/docs/chain-search.rst
@@ -51,7 +51,7 @@ injected into the ``$statisticSearcher``:
         /**
          * @param mixed $results
          */
-        public function transform($results, CriteriaCollectionInterface $criteria)
+        public function transform($results, CriteriaCollectionInterface $criteria): CriteriaCollectionInterface
         {
             // Assuming that UserIdsCriteria will holds an array of user IDs
             $userIdsCriteria = new UserIdsCriteria(array_map(
@@ -72,7 +72,7 @@ injected into the ``$statisticSearcher``:
          * @param mixed $results
          * @return bool
          */
-        public function skip($results)
+        public function skip($results): bool
         {
             return false;
         }

--- a/docs/class/criteria-builder.rst
+++ b/docs/class/criteria-builder.rst
@@ -37,7 +37,7 @@ will support Doctrine's searching context which is ``\KGzocha\Searcher\Context\D
 
     class SpecificAgeCriteriaBuilder extends AbstractORMCriteriaBuilder
     {
-        public function allowsCriteria(CriteriaInterface $criteria)
+        public function allowsCriteria(CriteriaInterface $criteria): bool
         {
             return $criteria instanceof SpecificAgeCriteria;
         }

--- a/docs/class/criteria.rst
+++ b/docs/class/criteria.rst
@@ -30,12 +30,12 @@ In order to to do you can create very simple class:
     {
         private $age;
 
-        public function getAge()
+        public function getAge(): int
         {
             return $this->age;
         }
 
-        public function setAge($age)
+        public function setAge(int $age)
         {
             $this->age = $age;
         }
@@ -44,7 +44,7 @@ In order to to do you can create very simple class:
         * Only required method.
         * If will return true, then it will be passed to some of the CriteriaBuilder(s)
         */
-        public function shouldBeApplied()
+        public function shouldBeApplied(): bool
         {
             return null !== $this->age;
         }
@@ -72,22 +72,22 @@ you should keep your ``Criteria`` as small as possible. It should be readable an
         private $minimumAge;
         private $maximumAge;
 
-        public function getMinimumAge()
+        public function getMinimumAge(): int
         {
             return $this->minimumAge;
         }
 
-        public function setMinimumAge($age)
+        public function setMinimumAge(int $age)
         {
             $this->minimumAge = $age;
         }
 
-        public function getMaximumAge()
+        public function getMaximumAge(): int
         {
             return $this->maximumAge;
         }
 
-        public function setMaximumAge($age)
+        public function setMaximumAge(int $age)
         {
             $this->maximumAge = $age;
         }
@@ -95,7 +95,7 @@ you should keep your ``Criteria`` as small as possible. It should be readable an
         /**
         * Please notice that there is OR condition inside
         */
-        public function shouldBeApplied()
+        public function shouldBeApplied(): bool
         {
             return null !== $this->minimumAge || null !== $this->maximumAge;
         }

--- a/docs/class/searching-context.rst
+++ b/docs/class/searching-context.rst
@@ -67,7 +67,7 @@ It will allow all criteria builders (that are supporting this context) to use Fi
         /**
         * @return Finder
         */
-        public function getQueryBuilder()
+        public function getQueryBuilder(): Finder
         {
             return $this->finder;
         }
@@ -75,7 +75,7 @@ It will allow all criteria builders (that are supporting this context) to use Fi
         /**
         * @return Iterator
         */
-        public function getResults()
+        public function getResults(): \Iterator
         {
             // I assumed that you want Iterator as a result
             return $this->finder->getIterator();

--- a/docs/complete-example.rst
+++ b/docs/complete-example.rst
@@ -26,7 +26,7 @@ in the criteria. We do not care about the pagination, nor order of the results.
         /**
          * @param null|float $height
          */
-        public function __construct($height = null)
+        public function __construct(float $height = null)
         {
             $this->height = $height;
         }
@@ -42,15 +42,15 @@ in the criteria. We do not care about the pagination, nor order of the results.
         /**
          * @param float $height
          */
-        public function setHeight($height)
+        public function setHeight(float $height)
         {
-            $this->height = (float) $height;
+            $this->height = $height;
         }
 
         /**
          * @inheritDoc
          */
-        public function shouldBeApplied()
+        public function shouldBeApplied(): bool
         {
             return $this->height != null;
         }
@@ -75,7 +75,7 @@ in the criteria. We do not care about the pagination, nor order of the results.
         /**
          * @inheritDoc
          */
-        public function allowsCriteria(CriteriaInterface $criteria)
+        public function allowsCriteria(CriteriaInterface $criteria): bool
         {
             return $criteria instanceof HeightCriteria;
         }
@@ -85,7 +85,8 @@ in the criteria. We do not care about the pagination, nor order of the results.
          */
         public function supportsSearchingContext(
             SearchingContextInterface $searchingContext
-        ) {
+        ): bool
+        {
             return $searchingContext instanceof QueryBuilderSearchingContext;
         }
     }

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -9,7 +9,7 @@ What?
 -----------------
 *Searcher* is a framework-agnostic search query builder.
 Search queries are written using Criterias and can be run against MySQL, MongoDB or even files.
-Supported PHP versions: >=5.4, 7 and HHVM.
+**Latest version is supporting only PHP 7.**
 You can find searcher in two most important places:
 
 - GitHub repository: https://github.com/krzysztof-gzocha/searcher

--- a/src/KGzocha/Searcher/AbstractCollection.php
+++ b/src/KGzocha/Searcher/AbstractCollection.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher;
 
@@ -29,14 +30,16 @@ abstract class AbstractCollection implements \Countable, \IteratorAggregate
      *
      * @return bool
      */
-    abstract protected function isItemValid($item);
+    abstract protected function isItemValid($item): bool;
 
     /**
      * {@inheritdoc}
      */
-    public function getIterator()
+    public function getIterator(): \Iterator
     {
-        return new \ArrayIterator($this->items);
+        foreach ($this->items as $key => $item) {
+            yield $key => $item;
+        }
     }
 
     /**
@@ -50,9 +53,9 @@ abstract class AbstractCollection implements \Countable, \IteratorAggregate
     /**
      * @param mixed $item
      *
-     * @return $this
+     * @return self
      */
-    protected function addItem($item)
+    protected function addItem($item): AbstractCollection
     {
         $this->items[] = $item;
 
@@ -63,9 +66,9 @@ abstract class AbstractCollection implements \Countable, \IteratorAggregate
      * @param string $name
      * @param mixed  $item
      *
-     * @return $this
+     * @return self
      */
-    protected function addNamedItem($name, $item)
+    protected function addNamedItem(string $name, $item): AbstractCollection
     {
         $this->items[$name] = $item;
 
@@ -85,7 +88,7 @@ abstract class AbstractCollection implements \Countable, \IteratorAggregate
      *
      * @return mixed|null
      */
-    protected function getNamedItem($name)
+    protected function getNamedItem(string $name)
     {
         if (array_key_exists($name, $this->items)) {
             return $this->items[$name];

--- a/src/KGzocha/Searcher/Chain/Cell.php
+++ b/src/KGzocha/Searcher/Chain/Cell.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Chain;
 
@@ -36,25 +37,25 @@ class Cell implements CellInterface
     }
 
     /**
-     * @return \KGzocha\Searcher\SearcherInterface
+     * @inheritdoc
      */
-    public function getSearcher()
+    public function getSearcher(): SearcherInterface
     {
         return $this->searcher;
     }
 
     /**
-     * @return TransformerInterface
+     * @inheritdoc
      */
-    public function getTransformer()
+    public function getTransformer(): TransformerInterface
     {
         return $this->transformer;
     }
 
     /**
-     * @return bool
+     * @inheritdoc
      */
-    public function hasTransformer()
+    public function hasTransformer(): bool
     {
         return !$this->transformer instanceof EndTransformer;
     }

--- a/src/KGzocha/Searcher/Chain/CellInterface.php
+++ b/src/KGzocha/Searcher/Chain/CellInterface.php
@@ -1,6 +1,9 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Chain;
+
+use KGzocha\Searcher\SearcherInterface;
 
 /**
  * It represents single cell in the chain. It holds sub-searcher and it's transformer, which will
@@ -12,17 +15,17 @@ namespace KGzocha\Searcher\Chain;
 interface CellInterface
 {
     /**
-     * @return \KGzocha\Searcher\SearcherInterface
+     * @return SearcherInterface
      */
-    public function getSearcher();
+    public function getSearcher(): SearcherInterface;
 
     /**
      * @return TransformerInterface
      */
-    public function getTransformer();
+    public function getTransformer(): TransformerInterface;
 
     /**
      * @return bool
      */
-    public function hasTransformer();
+    public function hasTransformer(): bool;
 }

--- a/src/KGzocha/Searcher/Chain/ChainSearch.php
+++ b/src/KGzocha/Searcher/Chain/ChainSearch.php
@@ -81,8 +81,7 @@ class ChainSearch implements SearcherInterface
         CellInterface $cell,
         CriteriaCollectionInterface $criteria,
         $results
-    ): CriteriaCollectionInterface
-    {
+    ): CriteriaCollectionInterface {
         if (!$cell->hasTransformer()) {
             return $criteria;
         }

--- a/src/KGzocha/Searcher/Chain/ChainSearch.php
+++ b/src/KGzocha/Searcher/Chain/ChainSearch.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Chain;
 
@@ -42,7 +43,7 @@ class ChainSearch implements SearcherInterface
      */
     public function search(
         CriteriaCollectionInterface $criteriaCollection
-    ) {
+    ): ResultCollection {
         $previousCriteria = $criteriaCollection;
         $previousResults = null;
         $result = new ResultCollection();
@@ -60,7 +61,7 @@ class ChainSearch implements SearcherInterface
                 $previousResults
             );
 
-            $result->addNamedItem($name, $previousResults);
+            $result->addNamedItem((string) $name, $previousResults);
         }
 
         return $result;
@@ -80,7 +81,8 @@ class ChainSearch implements SearcherInterface
         CellInterface $cell,
         CriteriaCollectionInterface $criteria,
         $results
-    ) {
+    ): CriteriaCollectionInterface
+    {
         if (!$cell->hasTransformer()) {
             return $criteria;
         }

--- a/src/KGzocha/Searcher/Chain/Collection/CellCollection.php
+++ b/src/KGzocha/Searcher/Chain/Collection/CellCollection.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Chain\Collection;
 
@@ -18,15 +19,15 @@ class CellCollection extends AbstractCollection implements CellCollectionInterfa
     /**
      * @inheritDoc
      */
-    protected function isItemValid($item)
+    protected function isItemValid($item): bool
     {
         return $item instanceof CellInterface;
     }
 
     /**
-     * @return \ArrayIterator
+     * @inheritdoc
      */
-    public function getIterator()
+    public function getIterator(): \Iterator
     {
         $this->validateNumberOfCells();
 
@@ -34,7 +35,7 @@ class CellCollection extends AbstractCollection implements CellCollectionInterfa
     }
 
     /**
-     * @return CellInterface[]
+     * @inheritdoc
      */
     public function getCells()
     {
@@ -44,32 +45,25 @@ class CellCollection extends AbstractCollection implements CellCollectionInterfa
     }
 
     /**
-     * @param string $name
-     *
-     * @return CellInterface|null
+     * @inheritdoc
      */
-    public function getNamedCell($name)
+    public function getNamedCell(string $name)
     {
         return $this->getNamedItem($name);
     }
 
     /**
-     * @param CellInterface $item
-     *
-     * @return $this
+     * @inheritdoc
      */
-    public function addCell(CellInterface $item)
+    public function addCell(CellInterface $item): CellCollectionInterface
     {
         return $this->addItem($item);
     }
 
     /**
-     * @param string        $name
-     * @param CellInterface $cell
-     *
-     * @return $this
+     * @inheritdoc
      */
-    public function addNamedCell($name, CellInterface $cell)
+    public function addNamedCell(string $name, CellInterface $cell): CellCollectionInterface
     {
         return $this->addNamedItem($name, $cell);
     }

--- a/src/KGzocha/Searcher/Chain/Collection/CellCollectionInterface.php
+++ b/src/KGzocha/Searcher/Chain/Collection/CellCollectionInterface.php
@@ -18,20 +18,20 @@ interface CellCollectionInterface extends \Countable, \IteratorAggregate
      *
      * @return CellInterface|null
      */
-    public function getNamedCell($name);
+    public function getNamedCell(string $name);
 
     /**
      * @param CellInterface $item
      *
-     * @return $this
+     * @return CellCollectionInterface
      */
-    public function addCell(CellInterface $item);
+    public function addCell(CellInterface $item): CellCollectionInterface;
 
     /**
      * @param string        $name
      * @param CellInterface $cell
      *
-     * @return $this
+     * @return CellCollectionInterface
      */
-    public function addNamedCell($name, CellInterface $cell);
+    public function addNamedCell(string $name, CellInterface $cell): CellCollectionInterface;
 }

--- a/src/KGzocha/Searcher/Chain/EndTransformer.php
+++ b/src/KGzocha/Searcher/Chain/EndTransformer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Chain;
 
@@ -15,7 +16,7 @@ final class EndTransformer implements TransformerInterface
     /**
      * {@inheritdoc}
      */
-    public function transform($results, CriteriaCollectionInterface $criteria)
+    public function transform($results, CriteriaCollectionInterface $criteria): CriteriaCollectionInterface
     {
         throw new \RuntimeException(
             'Transform method on EmptyTransformer should never be called.'
@@ -25,7 +26,7 @@ final class EndTransformer implements TransformerInterface
     /**
      * {@inheritdoc}
      */
-    public function skip($results)
+    public function skip($results): bool
     {
         return false;
     }

--- a/src/KGzocha/Searcher/Chain/TransformerInterface.php
+++ b/src/KGzocha/Searcher/Chain/TransformerInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Chain;
 
@@ -21,7 +22,7 @@ interface TransformerInterface
      *
      * @return CriteriaCollectionInterface
      */
-    public function transform($results, CriteriaCollectionInterface $criteria);
+    public function transform($results, CriteriaCollectionInterface $criteria): CriteriaCollectionInterface;
 
     /**
      * Important! Results might be null when cell will be used as first one.
@@ -30,5 +31,5 @@ interface TransformerInterface
      *
      * @return bool
      */
-    public function skip($results);
+    public function skip($results): bool;
 }

--- a/src/KGzocha/Searcher/Context/AbstractSearchingContext.php
+++ b/src/KGzocha/Searcher/Context/AbstractSearchingContext.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Context;
 

--- a/src/KGzocha/Searcher/Context/Doctrine/ODMBuilderSearchingContext.php
+++ b/src/KGzocha/Searcher/Context/Doctrine/ODMBuilderSearchingContext.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Context\Doctrine;
 
@@ -23,7 +24,7 @@ class ODMBuilderSearchingContext extends AbstractSearchingContext
     /**
      * @return Builder
      */
-    public function getQueryBuilder()
+    public function getQueryBuilder(): Builder
     {
         return parent::getQueryBuilder();
     }

--- a/src/KGzocha/Searcher/Context/Doctrine/QueryBuilderSearchingContext.php
+++ b/src/KGzocha/Searcher/Context/Doctrine/QueryBuilderSearchingContext.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Context\Doctrine;
 
@@ -24,7 +25,7 @@ class QueryBuilderSearchingContext extends AbstractSearchingContext
     /**
      * @return QueryBuilder
      */
-    public function getQueryBuilder()
+    public function getQueryBuilder(): QueryBuilder
     {
         return parent::getQueryBuilder();
     }

--- a/src/KGzocha/Searcher/Context/Elastica/QuerySearchingContext.php
+++ b/src/KGzocha/Searcher/Context/Elastica/QuerySearchingContext.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Context\Elastica;
 
@@ -38,7 +39,7 @@ class QuerySearchingContext extends AbstractSearchingContext
     /**
      * @return Query
      */
-    public function getQueryBuilder()
+    public function getQueryBuilder(): Query
     {
         return parent::getQueryBuilder();
     }
@@ -46,15 +47,15 @@ class QuerySearchingContext extends AbstractSearchingContext
     /**
      * @return Search
      */
-    public function getSearch()
+    public function getSearch(): Search
     {
         return $this->search;
     }
 
     /**
-     * @return ResultSet
+     * @return ResultSet|\Iterator
      */
-    public function getResults()
+    public function getResults(): \Iterator
     {
         $this->getSearch()->setQuery($this->getQueryBuilder());
 

--- a/src/KGzocha/Searcher/Context/Elastica/ScrollingSearchingContext.php
+++ b/src/KGzocha/Searcher/Context/Elastica/ScrollingSearchingContext.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Context\Elastica;
 
 use Elastica\Query;
+use Elastica\Scroll;
 use Elastica\Search;
 
 /**
@@ -18,16 +20,16 @@ class ScrollingSearchingContext extends QuerySearchingContext
     /**
      * @inheritDoc
      */
-    public function __construct(Search $search, Query $query = null, $expiryTime = '1m')
+    public function __construct(Search $search, Query $query = null, string $expiryTime = '1m')
     {
         parent::__construct($search, $query);
         $this->expiryTime = $expiryTime;
     }
 
     /**
-     * @return \Elastica\Scroll
+     * @return Scroll|\Iterator
      */
-    public function getResults()
+    public function getResults(): \Iterator
     {
         $this
             ->getSearch()

--- a/src/KGzocha/Searcher/Context/FinderSearchingContext.php
+++ b/src/KGzocha/Searcher/Context/FinderSearchingContext.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Context;
 
@@ -22,7 +23,7 @@ class FinderSearchingContext extends AbstractSearchingContext
     /**
      * @return Finder
      */
-    public function getQueryBuilder()
+    public function getQueryBuilder(): Finder
     {
         return parent::getQueryBuilder();
     }
@@ -30,7 +31,7 @@ class FinderSearchingContext extends AbstractSearchingContext
     /**
      * @return \Iterator
      */
-    public function getResults()
+    public function getResults(): \Iterator
     {
         return $this->getQueryBuilder()->getIterator();
     }
@@ -38,7 +39,7 @@ class FinderSearchingContext extends AbstractSearchingContext
     /**
      * @return FinderSearchingContext
      */
-    public static function buildDefault()
+    public static function buildDefault(): FinderSearchingContext
     {
         return new self(new Finder());
     }

--- a/src/KGzocha/Searcher/Context/SearchingContextInterface.php
+++ b/src/KGzocha/Searcher/Context/SearchingContextInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Context;
 

--- a/src/KGzocha/Searcher/Criteria/Adapter/ImmutablePaginationAdapter.php
+++ b/src/KGzocha/Searcher/Criteria/Adapter/ImmutablePaginationAdapter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Criteria\Adapter;
 
@@ -28,7 +29,7 @@ class ImmutablePaginationAdapter implements PaginationCriteriaInterface
     /**
      * {@inheritdoc}
      */
-    public function getPage()
+    public function getPage(): int
     {
         return $this->pagination->getPage();
     }
@@ -36,7 +37,7 @@ class ImmutablePaginationAdapter implements PaginationCriteriaInterface
     /**
      * {@inheritdoc}
      */
-    public function getItemsPerPage()
+    public function getItemsPerPage(): int
     {
         return $this->pagination->getItemsPerPage();
     }
@@ -44,7 +45,7 @@ class ImmutablePaginationAdapter implements PaginationCriteriaInterface
     /**
      * {@inheritdoc}
      */
-    public function setPage($page)
+    public function setPage(int $page = null)
     {
         return $this->pagination->setPage($page);
     }
@@ -55,7 +56,7 @@ class ImmutablePaginationAdapter implements PaginationCriteriaInterface
      *
      * {@inheritdoc}
      */
-    public function setItemsPerPage($itemsPerPage)
+    public function setItemsPerPage(int $itemsPerPage = null)
     {
         return $this
             ->pagination
@@ -67,7 +68,7 @@ class ImmutablePaginationAdapter implements PaginationCriteriaInterface
     /**
      * {@inheritdoc}
      */
-    public function shouldBeApplied()
+    public function shouldBeApplied(): bool
     {
         return $this->pagination->shouldBeApplied();
     }

--- a/src/KGzocha/Searcher/Criteria/Adapter/MappedOrderByAdapter.php
+++ b/src/KGzocha/Searcher/Criteria/Adapter/MappedOrderByAdapter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Criteria\Adapter;
 
@@ -49,7 +50,7 @@ class MappedOrderByAdapter implements OrderByCriteriaInterface
             return $this->fieldsMap[$this->getOrderBy()];
         }
 
-        return;
+        return null;
     }
 
     /**
@@ -71,7 +72,7 @@ class MappedOrderByAdapter implements OrderByCriteriaInterface
     /**
      * {@inheritdoc}
      */
-    public function setOrderBy($orderBy)
+    public function setOrderBy(string $orderBy = null)
     {
         return $this->orderBy->setOrderBy($orderBy);
     }
@@ -79,7 +80,7 @@ class MappedOrderByAdapter implements OrderByCriteriaInterface
     /**
      * {@inheritdoc}
      */
-    public function shouldBeApplied()
+    public function shouldBeApplied(): bool
     {
         return $this->orderBy->shouldBeApplied() && $this->rawValueExistsInFieldsMap();
     }
@@ -104,7 +105,7 @@ class MappedOrderByAdapter implements OrderByCriteriaInterface
     /**
      * @return bool
      */
-    private function rawValueExistsInFieldsMap()
+    private function rawValueExistsInFieldsMap(): bool
     {
         return array_key_exists($this->getOrderBy(), $this->fieldsMap);
     }

--- a/src/KGzocha/Searcher/Criteria/AlwaysAppliedCriteria.php
+++ b/src/KGzocha/Searcher/Criteria/AlwaysAppliedCriteria.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Criteria;
 
@@ -13,7 +14,7 @@ class AlwaysAppliedCriteria implements CriteriaInterface
     /**
      * {@inheritdoc}
      */
-    public function shouldBeApplied()
+    public function shouldBeApplied(): bool
     {
         return true;
     }

--- a/src/KGzocha/Searcher/Criteria/Collection/CriteriaCollection.php
+++ b/src/KGzocha/Searcher/Criteria/Collection/CriteriaCollection.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Criteria\Collection;
 
@@ -22,7 +23,7 @@ class CriteriaCollection extends AbstractCollection implements CriteriaCollectio
     /**
      * {@inheritdoc}
      */
-    public function getApplicableCriteria()
+    public function getApplicableCriteria(): CriteriaCollectionInterface
     {
         return new self(array_filter(
             $this->getItems(),
@@ -43,7 +44,7 @@ class CriteriaCollection extends AbstractCollection implements CriteriaCollectio
     /**
      * {@inheritdoc}
      */
-    public function addCriteria(CriteriaInterface $criteria)
+    public function addCriteria(CriteriaInterface $criteria): CriteriaCollectionInterface
     {
         return $this->addItem($criteria);
     }
@@ -51,7 +52,7 @@ class CriteriaCollection extends AbstractCollection implements CriteriaCollectio
     /**
      * {@inheritdoc}
      */
-    protected function isItemValid($item)
+    protected function isItemValid($item): bool
     {
         return $item instanceof CriteriaInterface;
     }

--- a/src/KGzocha/Searcher/Criteria/Collection/CriteriaCollectionInterface.php
+++ b/src/KGzocha/Searcher/Criteria/Collection/CriteriaCollectionInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Criteria\Collection;
 
@@ -18,7 +19,7 @@ interface CriteriaCollectionInterface extends \Countable, \IteratorAggregate
      *
      * @return CriteriaCollectionInterface
      */
-    public function getApplicableCriteria();
+    public function getApplicableCriteria(): CriteriaCollectionInterface;
 
     /**
      * @return CriteriaInterface[]
@@ -30,5 +31,5 @@ interface CriteriaCollectionInterface extends \Countable, \IteratorAggregate
      *
      * @return CriteriaCollectionInterface
      */
-    public function addCriteria(CriteriaInterface $criteria);
+    public function addCriteria(CriteriaInterface $criteria): CriteriaCollectionInterface;
 }

--- a/src/KGzocha/Searcher/Criteria/Collection/NamedCriteriaCollection.php
+++ b/src/KGzocha/Searcher/Criteria/Collection/NamedCriteriaCollection.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Criteria\Collection;
 
@@ -14,7 +15,7 @@ class NamedCriteriaCollection extends CriteriaCollection implements NamedCriteri
      *
      * @return null|CriteriaInterface
      */
-    public function __get($name)
+    public function __get(string $name)
     {
         return $this->getNamedCriteria($name);
     }
@@ -23,7 +24,7 @@ class NamedCriteriaCollection extends CriteriaCollection implements NamedCriteri
      * @param string            $name
      * @param CriteriaInterface $value
      */
-    public function __set($name, CriteriaInterface $value)
+    public function __set(string $name, CriteriaInterface $value)
     {
         $this->addNamedCriteria($name, $value);
     }
@@ -32,9 +33,9 @@ class NamedCriteriaCollection extends CriteriaCollection implements NamedCriteri
      * @param string            $name
      * @param CriteriaInterface $criteria
      *
-     * @return $this
+     * @return NamedCriteriaCollectionInterface
      */
-    public function addNamedCriteria($name, CriteriaInterface $criteria)
+    public function addNamedCriteria(string $name, CriteriaInterface $criteria): NamedCriteriaCollectionInterface
     {
         return $this->addNamedItem($name, $criteria);
     }

--- a/src/KGzocha/Searcher/Criteria/Collection/NamedCriteriaCollectionInterface.php
+++ b/src/KGzocha/Searcher/Criteria/Collection/NamedCriteriaCollectionInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Criteria\Collection;
 
@@ -17,12 +18,12 @@ interface NamedCriteriaCollectionInterface extends CriteriaCollectionInterface
      * @param string            $name
      * @param CriteriaInterface $criteria
      *
-     *@return $this
+     * @return NamedCriteriaCollectionInterface
      */
     public function addNamedCriteria(
-        $name,
+        string $name,
         CriteriaInterface $criteria
-    );
+    ): NamedCriteriaCollectionInterface;
 
     /**
      * @param string $name

--- a/src/KGzocha/Searcher/Criteria/CoordinatesCriteria.php
+++ b/src/KGzocha/Searcher/Criteria/CoordinatesCriteria.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Criteria;
 
@@ -21,14 +22,14 @@ class CoordinatesCriteria implements CriteriaInterface
      * @param float $latitude
      * @param float $longitude
      */
-    public function __construct($latitude = null, $longitude = null)
+    public function __construct(float $latitude = null, float $longitude = null)
     {
         $this->latitude = $latitude;
         $this->longitude = $longitude;
     }
 
     /**
-     * @return float
+     * @return float|null
      */
     public function getLatitude()
     {
@@ -38,13 +39,13 @@ class CoordinatesCriteria implements CriteriaInterface
     /**
      * @param float $latitude
      */
-    public function setLatitude($latitude)
+    public function setLatitude(float $latitude = null)
     {
-        $this->latitude = (float) $latitude;
+        $this->latitude = $latitude;
     }
 
     /**
-     * @return float
+     * @return float|null
      */
     public function getLongitude()
     {
@@ -54,15 +55,15 @@ class CoordinatesCriteria implements CriteriaInterface
     /**
      * @param float $longitude
      */
-    public function setLongitude($longitude)
+    public function setLongitude(float $longitude = null)
     {
-        $this->longitude = (float) $longitude;
+        $this->longitude = $longitude;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function shouldBeApplied()
+    public function shouldBeApplied(): bool
     {
         return $this->latitude !== null
             && $this->longitude !== null;

--- a/src/KGzocha/Searcher/Criteria/CriteriaInterface.php
+++ b/src/KGzocha/Searcher/Criteria/CriteriaInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Criteria;
 
@@ -13,5 +14,5 @@ interface CriteriaInterface
      *
      * @return bool
      */
-    public function shouldBeApplied();
+    public function shouldBeApplied(): bool;
 }

--- a/src/KGzocha/Searcher/Criteria/DateTimeCriteria.php
+++ b/src/KGzocha/Searcher/Criteria/DateTimeCriteria.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Criteria;
 
@@ -21,7 +22,7 @@ class DateTimeCriteria implements CriteriaInterface
     }
 
     /**
-     * @return \DateTime
+     * @return null|\DateTime
      */
     public function getDateTime()
     {
@@ -30,8 +31,6 @@ class DateTimeCriteria implements CriteriaInterface
 
     /**
      * @param \DateTime|null $dateTime
-     *
-     * @return DateTimeCriteria
      */
     public function setDateTime(\DateTime $dateTime = null)
     {
@@ -41,7 +40,7 @@ class DateTimeCriteria implements CriteriaInterface
     /**
      * {@inheritdoc}
      */
-    public function shouldBeApplied()
+    public function shouldBeApplied(): bool
     {
         return $this->dateTime instanceof \DateTime;
     }

--- a/src/KGzocha/Searcher/Criteria/DateTimeRangeCriteria.php
+++ b/src/KGzocha/Searcher/Criteria/DateTimeRangeCriteria.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Criteria;
 
@@ -30,7 +31,7 @@ class DateTimeRangeCriteria implements CriteriaInterface
     }
 
     /**
-     * @return \DateTime
+     * @return \DateTime|null
      */
     public function getStartingDateTime()
     {
@@ -39,8 +40,6 @@ class DateTimeRangeCriteria implements CriteriaInterface
 
     /**
      * @param \DateTime|null $startingDateTime
-     *
-     * @return DateTimeRangeCriteria
      */
     public function setStartingDateTime(
         \DateTime $startingDateTime = null
@@ -49,7 +48,7 @@ class DateTimeRangeCriteria implements CriteriaInterface
     }
 
     /**
-     * @return \DateTime
+     * @return \DateTime|null
      */
     public function getEndingDateTime()
     {
@@ -58,8 +57,6 @@ class DateTimeRangeCriteria implements CriteriaInterface
 
     /**
      * @param \DateTime|null $endingDateTime
-     *
-     * @return DateTimeRangeCriteria
      */
     public function setEndingDateTime(
         \DateTime $endingDateTime = null
@@ -70,7 +67,7 @@ class DateTimeRangeCriteria implements CriteriaInterface
     /**
      * {@inheritdoc}
      */
-    public function shouldBeApplied()
+    public function shouldBeApplied(): bool
     {
         return $this->startingDateTime instanceof \DateTime
             || $this->endingDateTime instanceof \DateTime;

--- a/src/KGzocha/Searcher/Criteria/IntegerCriteria.php
+++ b/src/KGzocha/Searcher/Criteria/IntegerCriteria.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Criteria;
 
@@ -15,13 +16,13 @@ class IntegerCriteria implements CriteriaInterface
     /**
      * @param int $integer
      */
-    public function __construct($integer = null)
+    public function __construct(int $integer = null)
     {
         $this->integer = $integer;
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getInteger()
     {
@@ -31,15 +32,15 @@ class IntegerCriteria implements CriteriaInterface
     /**
      * @param int $integer
      */
-    public function setInteger($integer)
+    public function setInteger(int $integer = null)
     {
-        $this->integer = (int) $integer;
+        $this->integer = $integer;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function shouldBeApplied()
+    public function shouldBeApplied(): bool
     {
         return $this->integer !== null;
     }

--- a/src/KGzocha/Searcher/Criteria/IntegerRangeCriteria.php
+++ b/src/KGzocha/Searcher/Criteria/IntegerRangeCriteria.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Criteria;
 
@@ -18,17 +19,17 @@ class IntegerRangeCriteria implements CriteriaInterface
     private $max;
 
     /**
-     * @param int $min
-     * @param int $max
+     * @param int|null $min
+     * @param int|null $max
      */
-    public function __construct($min = null, $max = null)
+    public function __construct(int $min = null, int $max = null)
     {
         $this->min = $min;
         $this->max = $max;
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getMin()
     {
@@ -38,9 +39,9 @@ class IntegerRangeCriteria implements CriteriaInterface
     /**
      * @param int $min
      */
-    public function setMin($min)
+    public function setMin(int $min = null)
     {
-        $this->min = (int) $min;
+        $this->min = $min;
     }
 
     /**
@@ -54,15 +55,15 @@ class IntegerRangeCriteria implements CriteriaInterface
     /**
      * @param int $max
      */
-    public function setMax($max)
+    public function setMax(int $max = null)
     {
-        $this->max = (int) $max;
+        $this->max = $max;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function shouldBeApplied()
+    public function shouldBeApplied(): bool
     {
         return $this->min !== null && $this->max !== null;
     }

--- a/src/KGzocha/Searcher/Criteria/NumberCriteria.php
+++ b/src/KGzocha/Searcher/Criteria/NumberCriteria.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Criteria;
 
@@ -15,13 +16,13 @@ class NumberCriteria implements CriteriaInterface
     /**
      * @param float $number
      */
-    public function __construct($number = null)
+    public function __construct(float $number = null)
     {
         $this->number = $number;
     }
 
     /**
-     * @return float
+     * @return float|null
      */
     public function getNumber()
     {
@@ -31,17 +32,16 @@ class NumberCriteria implements CriteriaInterface
     /**
      * @param float $number
      */
-    public function setNumber($number)
+    public function setNumber(float $number = null)
     {
-        $this->number = (float) $number;
+        $this->number = $number;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function shouldBeApplied()
+    public function shouldBeApplied(): bool
     {
-        return $this->number !== null
-            && is_numeric($this->number);
+        return $this->number !== null;
     }
 }

--- a/src/KGzocha/Searcher/Criteria/OrderByCriteria.php
+++ b/src/KGzocha/Searcher/Criteria/OrderByCriteria.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Criteria;
 
@@ -15,7 +16,7 @@ class OrderByCriteria implements OrderByCriteriaInterface
     /**
      * @param null|string $orderBy
      */
-    public function __construct($orderBy = null)
+    public function __construct(string $orderBy = null)
     {
         $this->orderBy = $orderBy;
     }
@@ -31,7 +32,7 @@ class OrderByCriteria implements OrderByCriteriaInterface
     /**
      * @param null|string $orderBy
      */
-    public function setOrderBy($orderBy)
+    public function setOrderBy(string $orderBy = null)
     {
         $this->orderBy = $orderBy;
     }
@@ -39,7 +40,7 @@ class OrderByCriteria implements OrderByCriteriaInterface
     /**
      * {@inheritdoc}
      */
-    public function shouldBeApplied()
+    public function shouldBeApplied(): bool
     {
         return $this->orderBy !== null && !empty($this->orderBy);
     }

--- a/src/KGzocha/Searcher/Criteria/OrderByCriteriaInterface.php
+++ b/src/KGzocha/Searcher/Criteria/OrderByCriteriaInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Criteria;
 
@@ -15,5 +16,5 @@ interface OrderByCriteriaInterface extends CriteriaInterface
     /**
      * @param null|string $orderBy
      */
-    public function setOrderBy($orderBy);
+    public function setOrderBy(string $orderBy = null);
 }

--- a/src/KGzocha/Searcher/Criteria/PaginationCriteria.php
+++ b/src/KGzocha/Searcher/Criteria/PaginationCriteria.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Criteria;
 
@@ -8,12 +9,12 @@ namespace KGzocha\Searcher\Criteria;
 class PaginationCriteria implements PaginationCriteriaInterface
 {
     /**
-     * @var int
+     * @var int|null
      */
     private $page;
 
     /**
-     * @var int
+     * @var int|null
      */
     private $itemsPerPage;
 
@@ -22,15 +23,15 @@ class PaginationCriteria implements PaginationCriteriaInterface
      * @param int $itemsPerPage
      */
     public function __construct(
-        $page = null,
-        $itemsPerPage = null
+        int $page = null,
+        int $itemsPerPage = null
     ) {
         $this->setPage($page);
         $this->setItemsPerPage($itemsPerPage);
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getPage()
     {
@@ -40,13 +41,13 @@ class PaginationCriteria implements PaginationCriteriaInterface
     /**
      * @param int $page
      */
-    public function setPage($page)
+    public function setPage(int $page = null)
     {
         $this->page = $this->convert($page);
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getItemsPerPage()
     {
@@ -58,7 +59,7 @@ class PaginationCriteria implements PaginationCriteriaInterface
      *
      * @throws \BadMethodCallException
      */
-    public function setItemsPerPage($itemsPerPage)
+    public function setItemsPerPage(int $itemsPerPage = null)
     {
         $this->itemsPerPage = $this->convert($itemsPerPage);
     }
@@ -66,7 +67,7 @@ class PaginationCriteria implements PaginationCriteriaInterface
     /**
      * {@inheritdoc}
      */
-    public function shouldBeApplied()
+    public function shouldBeApplied(): bool
     {
         return $this->page != 0 && $this->itemsPerPage != 0;
     }
@@ -76,8 +77,8 @@ class PaginationCriteria implements PaginationCriteriaInterface
      *
      * @return int
      */
-    private function convert($number)
+    private function convert(int $number = null): int
     {
-        return abs((int) $number);
+        return (int) abs($number);
     }
 }

--- a/src/KGzocha/Searcher/Criteria/PaginationCriteria.php
+++ b/src/KGzocha/Searcher/Criteria/PaginationCriteria.php
@@ -69,7 +69,7 @@ class PaginationCriteria implements PaginationCriteriaInterface
      */
     public function shouldBeApplied(): bool
     {
-        return $this->page != 0 && $this->itemsPerPage != 0;
+        return $this->page !== 0 && $this->itemsPerPage !== 0;
     }
 
     /**

--- a/src/KGzocha/Searcher/Criteria/PaginationCriteriaInterface.php
+++ b/src/KGzocha/Searcher/Criteria/PaginationCriteriaInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Criteria;
 
@@ -20,10 +21,10 @@ interface PaginationCriteriaInterface extends CriteriaInterface
     /**
      * @param int $page
      */
-    public function setPage($page);
+    public function setPage(int $page = null);
 
     /**
      * @param int $itemsPerPage
      */
-    public function setItemsPerPage($itemsPerPage);
+    public function setItemsPerPage(int $itemsPerPage = null);
 }

--- a/src/KGzocha/Searcher/Criteria/TextCriteria.php
+++ b/src/KGzocha/Searcher/Criteria/TextCriteria.php
@@ -1,24 +1,28 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Criteria;
 
+/**
+ * @author Krzysztof Gzocha <krzysztof@propertyfinder.ae>
+ */
 class TextCriteria implements CriteriaInterface
 {
     /**
-     * @var string
+     * @var string|null
      */
     private $text;
 
     /**
      * @param string $text
      */
-    public function __construct($text = null)
+    public function __construct(string $text = null)
     {
         $this->text = $text;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getText()
     {
@@ -27,18 +31,16 @@ class TextCriteria implements CriteriaInterface
 
     /**
      * @param string $text
-     *
-     * @return TextCriteria
      */
-    public function setText($text)
+    public function setText(string $text = null)
     {
-        $this->text = (string) $text;
+        $this->text = $text;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function shouldBeApplied()
+    public function shouldBeApplied(): bool
     {
         return $this->text !== null && 0 < mb_strlen($this->text);
     }

--- a/src/KGzocha/Searcher/CriteriaBuilder/Collection/CriteriaBuilderCollection.php
+++ b/src/KGzocha/Searcher/CriteriaBuilder/Collection/CriteriaBuilderCollection.php
@@ -41,8 +41,7 @@ class CriteriaBuilderCollection extends AbstractCollection implements CriteriaBu
      */
     public function getCriteriaBuildersForContext(
         SearchingContextInterface $searchingContext
-    ): CriteriaBuilderCollectionInterface
-    {
+    ): CriteriaBuilderCollectionInterface {
         return new self(array_filter(
             $this->getItems(),
             function (CriteriaBuilderInterface $criteriaBuilder) use ($searchingContext) {

--- a/src/KGzocha/Searcher/CriteriaBuilder/Collection/CriteriaBuilderCollection.php
+++ b/src/KGzocha/Searcher/CriteriaBuilder/Collection/CriteriaBuilderCollection.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\CriteriaBuilder\Collection;
 
@@ -22,7 +23,7 @@ class CriteriaBuilderCollection extends AbstractCollection implements CriteriaBu
     /**
      * {@inheritdoc}
      */
-    public function addCriteriaBuilder(CriteriaBuilderInterface $criteriaBuilder)
+    public function addCriteriaBuilder(CriteriaBuilderInterface $criteriaBuilder): CriteriaBuilderCollectionInterface
     {
         return $this->addItem($criteriaBuilder);
     }
@@ -40,7 +41,8 @@ class CriteriaBuilderCollection extends AbstractCollection implements CriteriaBu
      */
     public function getCriteriaBuildersForContext(
         SearchingContextInterface $searchingContext
-    ) {
+    ): CriteriaBuilderCollectionInterface
+    {
         return new self(array_filter(
             $this->getItems(),
             function (CriteriaBuilderInterface $criteriaBuilder) use ($searchingContext) {
@@ -52,7 +54,7 @@ class CriteriaBuilderCollection extends AbstractCollection implements CriteriaBu
     /**
      * {@inheritdoc}
      */
-    protected function isItemValid($item)
+    protected function isItemValid($item): bool
     {
         return $item instanceof CriteriaBuilderInterface;
     }

--- a/src/KGzocha/Searcher/CriteriaBuilder/Collection/CriteriaBuilderCollectionInterface.php
+++ b/src/KGzocha/Searcher/CriteriaBuilder/Collection/CriteriaBuilderCollectionInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\CriteriaBuilder\Collection;
 
@@ -20,7 +21,7 @@ interface CriteriaBuilderCollectionInterface extends \Countable, \IteratorAggreg
      */
     public function addCriteriaBuilder(
         CriteriaBuilderInterface $criteriaBuilder
-    );
+    ): CriteriaBuilderCollectionInterface;
 
     /**
      * @return CriteriaBuilderInterface[]
@@ -34,5 +35,5 @@ interface CriteriaBuilderCollectionInterface extends \Countable, \IteratorAggreg
      */
     public function getCriteriaBuildersForContext(
         SearchingContextInterface $searchingContext
-    );
+    ): CriteriaBuilderCollectionInterface;
 }

--- a/src/KGzocha/Searcher/CriteriaBuilder/CriteriaBuilderInterface.php
+++ b/src/KGzocha/Searcher/CriteriaBuilder/CriteriaBuilderInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\CriteriaBuilder;
 
@@ -34,14 +35,12 @@ interface CriteriaBuilderInterface
      *
      * @return bool
      */
-    public function allowsCriteria(CriteriaInterface $criteria);
+    public function allowsCriteria(CriteriaInterface $criteria): bool;
 
     /**
      * @param SearchingContextInterface $searchingContext
      *
      * @return bool
      */
-    public function supportsSearchingContext(
-        SearchingContextInterface $searchingContext
-    );
+    public function supportsSearchingContext(SearchingContextInterface $searchingContext): bool;
 }

--- a/src/KGzocha/Searcher/CriteriaBuilder/Doctrine/AbstractODMCriteriaBuilder.php
+++ b/src/KGzocha/Searcher/CriteriaBuilder/Doctrine/AbstractODMCriteriaBuilder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\CriteriaBuilder\Doctrine;
 
@@ -22,7 +23,8 @@ abstract class AbstractODMCriteriaBuilder implements CriteriaBuilderInterface
      */
     public function supportsSearchingContext(
         SearchingContextInterface $searchingContext
-    ) {
+    ): bool
+    {
         return $searchingContext instanceof ODMBuilderSearchingContext;
     }
 }

--- a/src/KGzocha/Searcher/CriteriaBuilder/Doctrine/AbstractODMCriteriaBuilder.php
+++ b/src/KGzocha/Searcher/CriteriaBuilder/Doctrine/AbstractODMCriteriaBuilder.php
@@ -23,8 +23,7 @@ abstract class AbstractODMCriteriaBuilder implements CriteriaBuilderInterface
      */
     public function supportsSearchingContext(
         SearchingContextInterface $searchingContext
-    ): bool
-    {
+    ): bool {
         return $searchingContext instanceof ODMBuilderSearchingContext;
     }
 }

--- a/src/KGzocha/Searcher/CriteriaBuilder/Doctrine/AbstractORMCriteriaBuilder.php
+++ b/src/KGzocha/Searcher/CriteriaBuilder/Doctrine/AbstractORMCriteriaBuilder.php
@@ -47,8 +47,7 @@ abstract class AbstractORMCriteriaBuilder implements CriteriaBuilderInterface
         string $join,
         string $alias,
         string $joinType
-    ): QueryBuilder
-    {
+    ): QueryBuilder{
         list($entity) = explode('.', $join);
 
         $joinParts = $queryBuilder->getDQLPart('join');
@@ -80,8 +79,7 @@ abstract class AbstractORMCriteriaBuilder implements CriteriaBuilderInterface
         string $alias,
         string $join,
         string $joinType
-    ): QueryBuilder
-    {
+    ): QueryBuilder {
         $existingJoin = array_filter(
             $joinParts,
             function (Join $joinObj) use ($alias, $join, $joinType) {

--- a/src/KGzocha/Searcher/CriteriaBuilder/Doctrine/AbstractORMCriteriaBuilder.php
+++ b/src/KGzocha/Searcher/CriteriaBuilder/Doctrine/AbstractORMCriteriaBuilder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\CriteriaBuilder\Doctrine;
 
@@ -23,7 +24,8 @@ abstract class AbstractORMCriteriaBuilder implements CriteriaBuilderInterface
      */
     public function supportsSearchingContext(
         SearchingContextInterface $searchingContext
-    ) {
+    ): bool
+    {
         return $searchingContext instanceof QueryBuilderSearchingContext;
     }
 
@@ -40,7 +42,12 @@ abstract class AbstractORMCriteriaBuilder implements CriteriaBuilderInterface
      *
      * @return QueryBuilder
      */
-    protected function join(QueryBuilder $queryBuilder, $join, $alias, $joinType)
+    protected function join(
+        QueryBuilder $queryBuilder,
+        string $join,
+        string $alias,
+        string $joinType
+    ): QueryBuilder
     {
         list($entity) = explode('.', $join);
 
@@ -69,11 +76,12 @@ abstract class AbstractORMCriteriaBuilder implements CriteriaBuilderInterface
      */
     protected function filterExistingJoins(
         QueryBuilder $queryBuilder,
-        $joinParts,
-        $alias,
-        $join,
-        $joinType
-    ) {
+        array $joinParts,
+        string $alias,
+        string $join,
+        string $joinType
+    ): QueryBuilder
+    {
         $existingJoin = array_filter(
             $joinParts,
             function (Join $joinObj) use ($alias, $join, $joinType) {

--- a/src/KGzocha/Searcher/CriteriaBuilder/Doctrine/AbstractORMCriteriaBuilder.php
+++ b/src/KGzocha/Searcher/CriteriaBuilder/Doctrine/AbstractORMCriteriaBuilder.php
@@ -24,8 +24,7 @@ abstract class AbstractORMCriteriaBuilder implements CriteriaBuilderInterface
      */
     public function supportsSearchingContext(
         SearchingContextInterface $searchingContext
-    ): bool
-    {
+    ): bool {
         return $searchingContext instanceof QueryBuilderSearchingContext;
     }
 
@@ -47,7 +46,7 @@ abstract class AbstractORMCriteriaBuilder implements CriteriaBuilderInterface
         string $join,
         string $alias,
         string $joinType
-    ): QueryBuilder{
+    ): QueryBuilder {
         list($entity) = explode('.', $join);
 
         $joinParts = $queryBuilder->getDQLPart('join');

--- a/src/KGzocha/Searcher/CriteriaBuilder/Elastica/AbstractQueryCriteriaBuilder.php
+++ b/src/KGzocha/Searcher/CriteriaBuilder/Elastica/AbstractQueryCriteriaBuilder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\CriteriaBuilder\Elastica;
 
@@ -19,7 +20,8 @@ abstract class AbstractQueryCriteriaBuilder implements CriteriaBuilderInterface
      */
     public function supportsSearchingContext(
         SearchingContextInterface $searchingContext
-    ) {
+    ): bool
+    {
         return $searchingContext instanceof QuerySearchingContext;
     }
 }

--- a/src/KGzocha/Searcher/CriteriaBuilder/Elastica/AbstractQueryCriteriaBuilder.php
+++ b/src/KGzocha/Searcher/CriteriaBuilder/Elastica/AbstractQueryCriteriaBuilder.php
@@ -20,8 +20,7 @@ abstract class AbstractQueryCriteriaBuilder implements CriteriaBuilderInterface
      */
     public function supportsSearchingContext(
         SearchingContextInterface $searchingContext
-    ): bool
-    {
+    ): bool {
         return $searchingContext instanceof QuerySearchingContext;
     }
 }

--- a/src/KGzocha/Searcher/ParameterGenerator/ParameterGenerator.php
+++ b/src/KGzocha/Searcher/ParameterGenerator/ParameterGenerator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\ParameterGenerator;
 
@@ -23,7 +24,7 @@ class ParameterGenerator implements ParameterGeneratorInterface
     /**
      * @param string $prefix
      */
-    public function __construct($prefix = 'searchParam')
+    public function __construct(string $prefix = 'searchParam')
     {
         $this->counter = 0;
         $this->prefix = $prefix;
@@ -32,7 +33,7 @@ class ParameterGenerator implements ParameterGeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function getParameterName()
+    public function getParameterName(): string
     {
         $this->counter += 1;
 

--- a/src/KGzocha/Searcher/ParameterGenerator/ParameterGeneratorInterface.php
+++ b/src/KGzocha/Searcher/ParameterGenerator/ParameterGeneratorInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\ParameterGenerator;
 
@@ -18,5 +19,5 @@ interface ParameterGeneratorInterface
      *
      * @return string
      */
-    public function getParameterName();
+    public function getParameterName(): string;
 }

--- a/src/KGzocha/Searcher/Result/ResultCollection.php
+++ b/src/KGzocha/Searcher/Result/ResultCollection.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Result;
 
@@ -18,7 +19,7 @@ class ResultCollection extends AbstractCollection implements ResultCollectionInt
     /**
      * @inheritDoc
      */
-    public function addNamedItem($name, $item)
+    public function addNamedItem(string $name, $item): AbstractCollection
     {
         return parent::addNamedItem($name, $item);
     }
@@ -42,7 +43,7 @@ class ResultCollection extends AbstractCollection implements ResultCollectionInt
     /**
      * @inheritDoc
      */
-    protected function isItemValid($item)
+    protected function isItemValid($item): bool
     {
         return true;
     }

--- a/src/KGzocha/Searcher/Result/ResultCollectionInterface.php
+++ b/src/KGzocha/Searcher/Result/ResultCollectionInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher\Result;
 

--- a/src/KGzocha/Searcher/Searcher.php
+++ b/src/KGzocha/Searcher/Searcher.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher;
 
@@ -6,6 +7,7 @@ use KGzocha\Searcher\Context\SearchingContextInterface;
 use KGzocha\Searcher\CriteriaBuilder\Collection\CriteriaBuilderCollectionInterface;
 use KGzocha\Searcher\Criteria\Collection\CriteriaCollectionInterface;
 use KGzocha\Searcher\Criteria\CriteriaInterface;
+use KGzocha\Searcher\CriteriaBuilder\CriteriaBuilderInterface;
 
 /**
  * Main class responsible for performing actual searching.
@@ -63,6 +65,7 @@ class Searcher implements SearcherInterface
         SearchingContextInterface $searchingContext,
         CriteriaBuilderCollectionInterface $builders
     ) {
+        /** @var CriteriaBuilderInterface $builder */
         foreach ($builders as $builder) {
             if ($builder->allowsCriteria($criteria)) {
                 $builder->buildCriteria($criteria, $searchingContext);

--- a/src/KGzocha/Searcher/SearcherInterface.php
+++ b/src/KGzocha/Searcher/SearcherInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher;
 

--- a/src/KGzocha/Searcher/WrappedResultsSearcher.php
+++ b/src/KGzocha/Searcher/WrappedResultsSearcher.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KGzocha\Searcher;
 
@@ -32,7 +33,8 @@ class WrappedResultsSearcher implements SearcherInterface
      */
     public function search(
         CriteriaCollectionInterface $criteriaCollection
-    ) {
+    ): ResultCollection
+    {
         return new ResultCollection(
             $this->searcher->search($criteriaCollection)
         );

--- a/src/KGzocha/Searcher/WrappedResultsSearcher.php
+++ b/src/KGzocha/Searcher/WrappedResultsSearcher.php
@@ -33,8 +33,7 @@ class WrappedResultsSearcher implements SearcherInterface
      */
     public function search(
         CriteriaCollectionInterface $criteriaCollection
-    ): ResultCollection
-    {
+    ): ResultCollection {
         return new ResultCollection(
             $this->searcher->search($criteriaCollection)
         );

--- a/tests/Chain/Collection/CellCollectionTest.php
+++ b/tests/Chain/Collection/CellCollectionTest.php
@@ -70,6 +70,6 @@ class CellCollectionTest extends \PHPUnit_Framework_TestCase
      */
     private function getCell()
     {
-        return $this->getMock('KGzocha\Searcher\Chain\CellInterface');
+        return $this->getMockBuilder(CellInterface::class)->getMock();
     }
 }

--- a/tests/Criteria/CoordinatesCriteriaTest.php
+++ b/tests/Criteria/CoordinatesCriteriaTest.php
@@ -60,8 +60,7 @@ class CoordinatesCriteriaTest extends AbstractCriteriaTestCase
     {
         return [
             [12.123, 23.233, 12.123, 23.233],
-            ['12.123', '23.233', 12.123, 23.233],
-            [null, '', 0.0, 0.0],
+            [null, null, 0.0, 0.0],
         ];
     }
 

--- a/tests/Criteria/IntegerCriteriaTest.php
+++ b/tests/Criteria/IntegerCriteriaTest.php
@@ -40,10 +40,6 @@ class IntegerCriteriaTest extends AbstractCriteriaTestCase
     {
         return [
             [10, true],
-            ['1a', true],
-            [10.12, true],
-            ['10.12', true],
-
             [null, false],
         ];
     }

--- a/tests/Criteria/NumberCriteriaTest.php
+++ b/tests/Criteria/NumberCriteriaTest.php
@@ -27,8 +27,6 @@ class NumberCriteriaTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [null, false],
-            ['non-numeric', false],
-
             [0, true],
             [1.0, true],
             [1, true],

--- a/tests/CriteriaBuilder/Doctrine/ORMCriteriaBuilderStub.php
+++ b/tests/CriteriaBuilder/Doctrine/ORMCriteriaBuilderStub.php
@@ -25,7 +25,7 @@ class ORMCriteriaBuilderStub extends AbstractORMCriteriaBuilder
     /**
      * {@inheritdoc}
      */
-    public function allowsCriteria(CriteriaInterface $criteria)
+    public function allowsCriteria(CriteriaInterface $criteria): bool
     {
         return true;
     }
@@ -33,7 +33,7 @@ class ORMCriteriaBuilderStub extends AbstractORMCriteriaBuilder
     /**
      * {@inheritdoc}
      */
-    public function join(QueryBuilder $queryBuilder, $join, $alias, $joinType)
+    public function join(QueryBuilder $queryBuilder, string $join, string $alias, string $joinType): QueryBuilder
     {
         return parent::join($queryBuilder, $join, $alias, $joinType);
     }
@@ -43,11 +43,12 @@ class ORMCriteriaBuilderStub extends AbstractORMCriteriaBuilder
      */
     public function filterExistingJoins(
         QueryBuilder $queryBuilder,
-        $joinParts,
-        $alias,
-        $join,
-        $joinType
-    ) {
+        array $joinParts,
+        string $alias,
+        string $join,
+        string $joinType
+    ): QueryBuilder
+    {
         return parent::filterExistingJoins(
             $queryBuilder,
             $joinParts,

--- a/tests/SearcherTest.php
+++ b/tests/SearcherTest.php
@@ -2,6 +2,8 @@
 
 namespace KGzocha\Searcher\Test;
 
+use KGzocha\Searcher\Context\SearchingContextInterface;
+use KGzocha\Searcher\Criteria\CriteriaInterface;
 use KGzocha\Searcher\CriteriaBuilder\Collection\CriteriaBuilderCollection;
 use KGzocha\Searcher\Criteria\Collection\CriteriaCollection;
 use KGzocha\Searcher\Searcher;
@@ -90,7 +92,8 @@ class SearcherTest extends \PHPUnit_Framework_TestCase
     private function getSearchingContext($result)
     {
         $context = $this
-            ->getMock('\KGzocha\Searcher\Context\SearchingContextInterface');
+            ->getMockBuilder(SearchingContextInterface::class)
+            ->getMock();
 
         $context
             ->expects($this->once())
@@ -106,9 +109,7 @@ class SearcherTest extends \PHPUnit_Framework_TestCase
     private function getCriteria()
     {
         $model = $this
-            ->getMockBuilder(
-                '\KGzocha\Searcher\Criteria\CriteriaInterface'
-            )
+            ->getMockBuilder(CriteriaInterface::class)
             ->getMock();
 
         $model


### PR DESCRIPTION
# Description
- [x] Introducing PHP 7 with strict_types
- [x] Fixed small bugs in PHPDocs
- [x] Drop support of PHP 5. Update composer.json
- [x] Upgrade PHPUnit version in composer.json

# Tests
## PHPUnit
```bash
$ ./bin/phpunit
PHPUnit 5.7.0 by Sebastian Bergmann and contributors.

...............................................................  63 / 190 ( 33%)
............................................................... 126 / 190 ( 66%)
............................................................... 189 / 190 ( 99%)
.                                                               190 / 190 (100%)

Time: 1.25 seconds, Memory: 8.00MB

OK (190 tests, 280 assertions)

Code Coverage Report:
  2016-12-02 09:38:03

 Summary:
  Classes: 100.00% (33/33)
  Methods: 100.00% (136/136)
  Lines:   100.00% (265/265)
```

## Humbug
```bash
54 mutations were generated:
      54 mutants were killed
       0 mutants were not covered by tests
       0 covered mutants were not detected
       0 fatal errors were encountered
       0 time outs were encountered

Metrics:
    Mutation Score Indicator (MSI): 100%
    Mutation Code Coverage: 100%
    Covered Code MSI: 100%
```
